### PR TITLE
Fix: Ensure OpenGL context is initialized for GrayscaleFilter

### DIFF
--- a/src/filter/grayscale_filter.cc
+++ b/src/filter/grayscale_filter.cc
@@ -36,9 +36,11 @@ const std::string kGrayscaleFragmentShaderString = R"(
 
 std::shared_ptr<GrayscaleFilter> GrayscaleFilter::Create() {
   auto ret = std::shared_ptr<GrayscaleFilter>(new GrayscaleFilter());
-  if (!ret->Init()) {
-    ret.reset();
-  }
+  gpupixel::GPUPixelContext::GetInstance()->SyncRunWithContext([&] {
+    if (!ret->Init()) {
+      ret.reset();
+    }
+  });
   return ret;
 }
 


### PR DESCRIPTION
**Problem:**
GrayscaleFilter was crashing with Segmentation fault during initialization because it was creating OpenGL shaders outside of the OpenGL context. This affected all filters that depend on GrayscaleFilter (like CannyEdgeDetectionFilter).

**Fix:**
Added `SyncRunWithContext` in `GrayscaleFilter::Create()` to ensure shader creation happens in the correct OpenGL context:
```cpp
std::shared_ptr<GrayscaleFilter> GrayscaleFilter::Create() {
  auto ret = std::shared_ptr<GrayscaleFilter>(new GrayscaleFilter());
  gpupixel::GPUPixelContext::GetInstance()->SyncRunWithContext([&] {
    if (!ret->Init()) {
      ret.reset();
    }
  });
  return ret;
}
```

**Testing:**
Both GrayscaleFilter and CannyEdgeDetectionFilter now work correctly.