### PR TITLE
fix GPUPixelSinkSurface failed to create on Android

### DIFF
--- a/demo/android/app/build.gradle
+++ b/demo/android/app/build.gradle
@@ -44,7 +44,7 @@ android {
 }
 
 dependencies {
-    implementation files('libs/gpupixel-release.aar')
+    implementation project(':gpupixel')
     implementation 'androidx.appcompat:appcompat:1.4.0'
     implementation 'com.google.android.material:material:1.4.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.2'

--- a/demo/android/settings.gradle
+++ b/demo/android/settings.gradle
@@ -8,3 +8,6 @@ dependencyResolutionManagement {
 }
 rootProject.name = "demo"
 include ':app'
+include ':gpupixel'
+project(':gpupixel').projectDir = new File('../../src/android/java/gpupixel')
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -100,7 +100,8 @@ set(jni_source_files
     ${CMAKE_CURRENT_SOURCE_DIR}/android/jni/jni_source_image.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/android/jni/jni_face_detector.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/android/jni/jni_sink_raw_data.cc
-    ${CMAKE_CURRENT_SOURCE_DIR}/android/jni/jni_sink_raw_yuv.cc)
+    ${CMAKE_CURRENT_SOURCE_DIR}/android/jni/jni_sink_raw_yuv.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/android/jni/jni_sink_surface.cc)
 
 set(lib_source_code_files ${common_source_files})
 


### PR DESCRIPTION
fix: GPUPixelSinkSurface failed to create on Android
demo: depend on gpupixel source module instead of prebuilt aar（demo直接联编gpupixel方便调试）